### PR TITLE
Prevent creating a docs PR if there's nothing to commit

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -14,8 +14,6 @@ defaults:
 jobs:
   run-php-documentor:
     runs-on: ubuntu-latest
-    env:
-      CREATE_PR: false
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -41,10 +39,9 @@ jobs:
 
       - name: Commit changes to docs/ folder (if any)
         run: |
-          git add . && git commit -m "Update docs/ folder" && git push origin ${{ env.BRANCH }} && echo "CREATE_PR=true" >> $GITHUB_ENV
+          if git add . && git commit -m "Update docs/ folder"; then git push origin ${{ env.BRANCH }} && echo "CREATE_PR=true" >> $GITHUB_ENV; else echo "CREATE_PR=false" >> $GITHUB_ENV; fi
 
       - name: Create PR
-        if: ${{ env.CREATE_PR }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE_TITLE: Generated docs using PHPDocumentor
@@ -52,4 +49,4 @@ jobs:
           LABELS: generated
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          bin/hub pull-request -b dev -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -l "$LABELS"
+          if ${{ env.CREATE_PR }}; then bin/hub pull-request -b dev -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -l "$LABELS"; fi

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -34,14 +34,14 @@ jobs:
 
       - name: Config Git user
         run: |
-          git config --global user.email "GraphTooling@service.microsoft.com"
-          git config --global user.name "Microsoft Graph DevX Tooling"
-
-      - name: Commit changes to docs/ folder (if any)
-        run: |
-          if git add . && git commit -m "Update docs/ folder"; then git push origin ${{ env.BRANCH }} && echo "CREATE_PR=true" >> $GITHUB_ENV; else echo "CREATE_PR=false" >> $GITHUB_ENV; fi
+          if git add . && git commit -m "Update docs/ folder"; then
+            git push origin ${{ env.BRANCH }} && echo "CREATE_PR=true" >> $GITHUB_ENV
+          else
+            echo "CREATE_PR=false" >> $GITHUB_ENV
+          fi
 
       - name: Create PR
+        if: ${{ env.CREATE_PR == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE_TITLE: Generated docs using PHPDocumentor
@@ -49,4 +49,4 @@ jobs:
           LABELS: generated
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          if ${{ env.CREATE_PR }}; then bin/hub pull-request -b dev -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -l "$LABELS"; fi
+          bin/hub pull-request -b dev -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -l "$LABELS"


### PR DESCRIPTION
Fixes bug in workflow where the workflow fails because it's trying to create a PR yet there are no new changes