### PR TITLE
Add page iterator

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -8,7 +8,6 @@
 namespace Microsoft\Graph\Http;
 
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Utils;
 use Http\Client\HttpAsyncClient;
 use Http\Promise\Promise;

--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -17,7 +17,6 @@
 
 namespace Microsoft\Graph\Http;
 
-use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -33,7 +32,7 @@ class GraphResponse
 
     /**
      * The request object
-     * @var object
+     * @var GraphRequest
      */
 
     private $_request;
@@ -206,5 +205,15 @@ class GraphResponse
             return $this->getBody()["@odata.count"];
         }
         return null;
+    }
+
+    /**
+     * Gets the request that triggered the response
+     *
+     * @return GraphRequest
+     */
+    public function getRequest(): GraphRequest
+    {
+        return $this->_request;
     }
 }

--- a/src/Http/RequestOptions.php
+++ b/src/Http/RequestOptions.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Graph\Http;
+
+/**
+ * Class RequestOptions
+ * Configure custom properties to add to the request
+ *
+ * @package Microsoft\Graph\Http
+ * @copyright 2021 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class RequestOptions
+{
+    /**
+     * @var array<string, string|string[]> custom headers to add to the request
+     */
+    private $headers = [];
+
+    /**
+     * RequestOptions constructor.
+     * @param array<string, string|string[]> $headers custom headers to add to the request
+     */
+    public function __construct(array $headers = [])
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * Gets the headers to add to the request
+     *
+     * @return array<string, string|string[]>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+}

--- a/src/Task/PageIterator.php
+++ b/src/Task/PageIterator.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Graph\Task;
+
+use Http\Promise\FulfilledPromise;
+use Http\Promise\Promise;
+use Microsoft\Graph\Exception\GraphClientException;
+use Microsoft\Graph\Exception\GraphException;
+use Microsoft\Graph\Http\AbstractGraphClient;
+use Microsoft\Graph\Http\GraphResponse;
+use Microsoft\Graph\Http\RequestOptions;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * Class PageIterator
+ * Allows passing a callback function to execute against each entity in a collection.
+ * The callback function must return a boolean to tell the PageIterator to pause/stop iterating
+ *
+ * @package Microsoft\Graph\Task
+ * @copyright 2021 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class PageIterator
+{
+    /**
+     * Graph client to use to make the request
+     *
+     * @var AbstractGraphClient
+     */
+    private $graphClient;
+    /**
+     * Response from a collection request
+     *
+     * @var GraphResponse
+     */
+    private $collectionResponse;
+    /**
+     * Collection of items to iterate through.
+     *
+     * @var array
+     */
+    private $entityCollection;
+    /**
+     * Callback function to execute against each entity in $entityCollection.
+     * Must return bool. If false, iteration pauses and can be resumed by calling resume(). If true, iteration proceeds
+     *
+     * @var callable(): bool
+     */
+    private $callback;
+    /**
+     * Custom request configs to add to subsequent calls to $entityCollection's @odata.nextLink
+     *
+     * @var RequestOptions|null
+     */
+    private $requestOptions;
+    /**
+     * Class type to deserialize future nextLink response payloads to
+     * Should match argument type expected by $callback
+     * If empty, an array of each JSON-decoded entity is passed to $callback
+     *
+     * @var string
+     */
+    private $returnType;
+    /**
+     * Index of next item to be passed to $callback.
+     * Allows resumable iteration
+     *
+     * @var int
+     */
+    private $currentIndex = 0;
+    /**
+     * Determine if iteration is complete or not
+     *
+     * @var bool
+     */
+    private $complete = false;
+
+    /**
+     * PageIterator constructor.
+     * @param AbstractGraphClient $graphClient to be used to make the request
+     * @param GraphResponse $collectionResponse initial collection of items to iterate through. Must contain @odata.nextLink
+     * @param callable(): bool $callback function to execute against each element of $entityCollection. Must return boolean which determines if iteration should pause/proceed
+     * @param string $returnType (optional) class to cast subsequent responses to after requesting the next link. Should be compatible with $callback's expected argument type
+*                                 if empty, each entity will be JSON-decoded to an array and passed to $callback
+     * @param RequestOptions|null $requestOptions (optional) custom headers/middleware to use for subsequent calls to $entityCollection's nextLink
+     *
+     * @throws GraphClientException
+     */
+    public function __construct(AbstractGraphClient $graphClient,
+                                GraphResponse $collectionResponse,
+                                callable $callback,
+                                string $returnType = '',
+                                ?RequestOptions $requestOptions = null) {
+        if (!$collectionResponse->getNextLink()) {
+            throw new GraphClientException("Entity collection provided must contain an @odata.nextLink");
+        }
+
+        $this->graphClient = $graphClient;
+        $this->collectionResponse = $collectionResponse;
+        $this->entityCollection = $collectionResponse->getBody()["value"];
+        $this->callback = $callback;
+        $this->returnType = $returnType;
+        $this->requestOptions = $requestOptions;
+    }
+
+    /**
+     * Passes each item in $entityCollection to $callback and continues calling nextLink there are no more items in the collection
+     * Iteration pauses if $callback returns false
+     *
+     * @return Promise that resolves to true on completion and throws error on rejection
+     *
+     * @throws \Exception if promise is rejected
+     */
+    public function iterate(): Promise {
+        $promise = new FulfilledPromise(false);
+        return $promise->then(function ($result) {
+            $callbackContinue = false;
+            while (!$this->complete) {
+                if (empty($this->entityCollection)) {
+                    $this->complete = true;
+                    break;
+                }
+
+                if ($this->currentIndex == (sizeof($this->entityCollection))) {
+                    if (!$this->getNextLink()) {
+                        $this->complete = true;
+                        break;
+                    }
+                    $this->getNextPage();
+                    $this->currentIndex = 0;
+                    continue;
+                }
+                $entity = $this->entityCollection[$this->currentIndex];
+                $callbackContinue = call_user_func($this->callback, $entity);
+                $this->currentIndex++;
+                if (!$callbackContinue) {
+                    break;
+                }
+            }
+            return true;
+
+        }, function ($reason) {
+            throw $reason;
+        });
+    }
+
+    /**
+     * Resume iteration after $callback returning false
+     *
+     * @return Promise
+     * @throws \Exception if promise is rejected
+     */
+    public function resume(): Promise {
+        return $this->iterate();
+    }
+
+    /**
+     * Check if iteration has happened across all pages of the collection.
+     * Can be false if iteration has been paused by $callback before all pages were processed
+     *
+     * @return bool
+     */
+    public function isComplete(): bool
+    {
+        return $this->complete;
+    }
+
+    /**
+     * Get delta link of the current collection
+     *
+     * @return string|null
+     */
+    public function getDeltaLink(): ?string {
+        return $this->collectionResponse->getDeltaLink();
+    }
+
+    /**
+     * Get next link of the current collection
+     *
+     * @return string|null
+     */
+    public function getNextLink(): ?string {
+        return $this->collectionResponse->getNextLink();
+    }
+
+    /**
+     * Fetches the next page of results
+     *
+     * @throws GraphClientException
+     * @throws ClientExceptionInterface
+     */
+    private function getNextPage(): void {
+        $nextLink = $this->getNextLink();
+        $request = $this->graphClient->createRequest("GET", $nextLink);
+        if ($this->requestOptions) {
+            $request = $request->addHeaders($this->requestOptions->getHeaders());
+        }
+        $this->collectionResponse = $request->execute();
+        if (!$this->collectionResponse || empty($this->collectionResponse->getBody())) {
+            $this->entityCollection = [];
+            return;
+        }
+        if (!$this->returnType) {
+            if (array_key_exists("value", $this->collectionResponse->getBody())) {
+                $this->entityCollection = $this->collectionResponse->getBody()["value"];
+                return;
+            }
+            throw new GraphClientException("No 'value' attribute found in payload after requesting ".$nextLink);
+        }
+        $this->entityCollection = $this->collectionResponse->getResponseAsObject($this->returnType);
+    }
+}

--- a/tests/Http/Request/RequestOptionsTest.php
+++ b/tests/Http/Request/RequestOptionsTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Graph\Test\Http\Request;
+
+
+use Microsoft\Graph\Http\RequestOptions;
+
+class RequestOptionsTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCreateRequestOptions() {
+        $headers = ["header" => "value"];
+        $requestOptions = new RequestOptions($headers);
+        $this->assertInstanceOf(RequestOptions::class, $requestOptions);
+        $this->assertEquals($headers, $requestOptions->getHeaders());
+    }
+}

--- a/tests/Http/SampleGraphResponsePayload.php
+++ b/tests/Http/SampleGraphResponsePayload.php
@@ -23,6 +23,7 @@ class SampleGraphResponsePayload
     const COLLECTION_PAYLOAD = [
         "@odata.count" => 2,
         "@odata.nextLink" => "https://graph.microsoft.com/me/users?\$skip=2&\$top=2",
+        "@odata.deltaLink" => "https://graph.microsoft.com/123123-asfd-212412-adfsdf",
         "value" => [
             [
                 "id" => 1,
@@ -39,12 +40,12 @@ class SampleGraphResponsePayload
         "@odata.count" => 2,
         "value" => [
             [
-                "id" => 1,
-                "givenName" => "user1"
+                "id" => 3,
+                "givenName" => "user3"
             ],
             [
-                "id" => 2,
-                "givenName" => "user2"
+                "id" => 4,
+                "givenName" => "user4"
             ]
         ]
     ];

--- a/tests/Task/PageIteratorTest.php
+++ b/tests/Task/PageIteratorTest.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Graph\Test\Task;
+
+
+use GuzzleHttp\Psr7\Utils;
+use Hoa\Iterator\Mock;
+use Microsoft\Graph\Exception\GraphClientException;
+use Microsoft\Graph\Http\GraphCollectionRequest;
+use Microsoft\Graph\Http\GraphResponse;
+use Microsoft\Graph\Http\RequestOptions;
+use Microsoft\Graph\Task\PageIterator;
+use Microsoft\Graph\Test\Http\Request\BaseGraphRequestTest;
+use Microsoft\Graph\Test\Http\Request\MockHttpClientResponseConfig;
+use Microsoft\Graph\Test\Http\SampleGraphResponsePayload;
+use Microsoft\Graph\Test\TestData\Model\User;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+
+
+class PageIteratorTest extends BaseGraphRequestTest
+{
+    private $defaultCollectionResponse;
+    private $defaultPageIterator;
+    private $defaultCallback;
+    private $callbackNumEntitiesProcessed = 0;
+    private $callbackIsEntityUser = false;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setupCallback();
+        $this->defaultCollectionResponse = $this->createCollectionResponse(SampleGraphResponsePayload::COLLECTION_PAYLOAD);
+        $this->defaultPageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $this->defaultCallback,
+        );
+        $this->setupNextPageRequest();
+    }
+
+    private function setupNextPageRequest() {
+        $this->mockGraphClient->method('createRequest')
+                                ->willReturn($this->defaultGraphRequest);
+    }
+
+    private function setupCallback() {
+        $this->callbackNumEntitiesProcessed = 0;
+        $this->callbackIsEntityUser = false;
+        $this->defaultCallback = function ($entity) {
+            if (is_a($entity, User::class)) {
+                $this->callbackIsEntityUser = true;
+                $this->callbackNumEntitiesProcessed ++;
+                return false;
+            }
+
+            $this->callbackNumEntitiesProcessed ++;
+            return true;
+        };
+    }
+
+    public function testConstructorCreatesPageIterator() {
+        $pageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $this->defaultCallback
+        );
+        $this->assertInstanceOf(PageIterator::class, $pageIterator);
+    }
+
+    public function testConstructorThrowsExceptionIfNoNextLink() {
+        $this->expectException(GraphClientException::class);
+        $pageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->createCollectionResponse(SampleGraphResponsePayload::LAST_PAGE_COLLECTION_PAYLOAD),
+            $this->defaultCallback
+        );
+    }
+
+    public function testIterateCallsCallbackForEachItemInCollection() {
+        // Set response for call to get the next page
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+
+        $numEntitiesInCollection = sizeof(SampleGraphResponsePayload::COLLECTION_PAYLOAD["value"]) + sizeof(SampleGraphResponsePayload::LAST_PAGE_COLLECTION_PAYLOAD["value"]);
+        $promise = $this->defaultPageIterator->iterate();
+        $promise->wait();
+        $this->assertEquals($numEntitiesInCollection, $this->callbackNumEntitiesProcessed);
+    }
+
+    public function testIteratePausesIfCallbackReturnsFalse() {
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+
+        // callback returns false if it encounters an entity of type User
+        $iterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $this->defaultCallback,
+            User::class
+        );
+        $promise = $iterator->iterate();
+        $promise->wait();
+        $this->assertEquals(3, $this->callbackNumEntitiesProcessed);
+    }
+
+    public function testIterateCastsNextPageResultsToExpectedReturnType() {
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+
+        $pageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $this->defaultCallback,
+            User::class
+        );
+        $promise = $pageIterator->iterate();
+        $promise->wait();
+        $this->assertTrue($this->callbackIsEntityUser);
+    }
+
+    public function testIterateCompletesIfTheresNoNextLinkToFetch() {
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+
+        $promise = $this->defaultPageIterator->iterate();
+        $promise->wait();
+        $this->assertTrue($this->defaultPageIterator->isComplete());
+    }
+
+    public function testIterateCompletesIfNextPageIsEmpty() {
+        MockHttpClientResponseConfig::configureWithEmptyPayload($this->mockHttpClient);
+        $promise = $this->defaultPageIterator->iterate();
+        $promise->wait();
+        $this->assertTrue($this->defaultPageIterator->isComplete());
+    }
+
+    public function testIterateThrowsExceptionOnErrorGettingNextPage() {
+        $this->expectException(ClientExceptionInterface::class);
+        $this->mockHttpClient->method('sendRequest')
+                                ->willThrowException($this->createMock(NetworkExceptionInterface::class));
+        $promise = $this->defaultPageIterator->iterate();
+        $promise->wait();
+    }
+
+    public function testIterateReturnsPromiseThatResolvesToTrueOnFulfilled() {
+        MockHttpClientResponseConfig::configureWithEmptyPayload($this->mockHttpClient);
+        $promise = $this->defaultPageIterator->iterate();
+        $this->assertTrue($promise->wait());
+    }
+
+    public function testIterateUsingCallbackWithNoReturnValueIsOnlyCalledOnce() {
+        $numEntitiesProcessed = 0;
+        $callback = function ($entity) use (&$numEntitiesProcessed) {
+            $numEntitiesProcessed ++;
+        };
+
+        $pageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $callback
+        );
+
+        $promise = $pageIterator->iterate();
+        $promise->wait();
+        $this->assertEquals(1, $numEntitiesProcessed);
+    }
+
+    public function testIteratorGetsNextPageUsingRequestOptions() {
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+        $header = ["SampleHeader" => ["value"]];
+        $requestOptions = new RequestOptions($header);
+        $pageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $this->defaultCallback,
+            '',
+            $requestOptions
+        );
+        $promise = $pageIterator->iterate();
+        $promise->wait();
+        $this->assertArrayHasKey("SampleHeader", $this->defaultGraphRequest->getHeaders());
+        $this->assertEquals($header["SampleHeader"], $this->defaultGraphRequest->getHeaders()["SampleHeader"]);
+    }
+
+    public function testResumeContinuesIteration() {
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+
+        $pageIterator = new PageIterator(
+            $this->mockGraphClient,
+            $this->defaultCollectionResponse,
+            $this->defaultCallback,
+            User::class
+        );
+
+        $promise = $pageIterator->iterate();
+        $promise->wait();
+        // iterator pauses
+        $this->assertEquals(3, $this->callbackNumEntitiesProcessed);
+        $promise = $pageIterator->resume();
+        $expectedNumEntities = sizeof(SampleGraphResponsePayload::COLLECTION_PAYLOAD["value"]) + sizeof(SampleGraphResponsePayload::LAST_PAGE_COLLECTION_PAYLOAD["value"]);
+        $this->assertEquals($expectedNumEntities, $this->callbackNumEntitiesProcessed);
+    }
+
+    public function testGetNextLinkChangesAfterNextPageIsFetched() {
+        $this->assertEquals($this->defaultCollectionResponse->getNextLink(), $this->defaultPageIterator->getNextLink());
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+        $promise = $this->defaultPageIterator->iterate();
+        $promise->wait();
+        $this->assertNull($this->defaultPageIterator->getNextLink());
+    }
+
+    public function testGetDeltaLinkChangesAfterNextPageIsFetched() {
+        $this->assertEquals($this->defaultCollectionResponse->getDeltaLink(), $this->defaultPageIterator->getDeltaLink());
+        MockHttpClientResponseConfig::configureWithLastPageCollectionPayload($this->mockHttpClient);
+        $promise = $this->defaultPageIterator->iterate();
+        $promise->wait();
+        $this->assertNull($this->defaultPageIterator->getDeltaLink());
+    }
+
+    private function createCollectionResponse(array $payload): GraphResponse {
+        return new GraphResponse(
+            $this->createMock(GraphCollectionRequest::class),
+            Utils::streamFor(json_encode($payload)),
+            200
+        );
+    }
+}


### PR DESCRIPTION
- Adds page iterator based on [SDK design guideline](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/tasks/PageIteratorTask.md)
- Implements proposed [SDK design improvement](https://github.com/microsoftgraph/msgraph-sdk-design/issues/37) to expose the page iterator via a method on the GraphCollectionRequest object
- Refactors `getPage()` on GraphCollectionRequest to return a GraphResponse object if no return type is specified. Previously would return the JSON-decoded body
- Adds a RequestOptions object that can be added in future minor revisions to set middleware on GraphRequests.


Closes https://github.com/microsoftgraph/msgraph-sdk-php/issues/516