### PR TITLE
Update sdk version header

### DIFF
--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -18,6 +18,9 @@ namespace Microsoft\Graph\Core;
 
 final class GraphConstants
 {
+    const BETA_API_VERSION = "beta";
+    const V1_API_VERSION = "v1.0";
+
     // These can be overwritten in setters in the Graph object
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -344,7 +344,11 @@ class GraphRequest
     private function initHeaders(string $baseUrl): void
     {
         $coreSdkVersion = "graph-php-core/".GraphConstants::SDK_VERSION;
-        $serviceLibSdkVersion = "Graph-php-".$this->graphClient->getSdkVersion();
+        if ($this->graphClient->getApiVersion() === GraphConstants::BETA_API_VERSION) {
+            $serviceLibSdkVersion = "graph-php-beta/".$this->graphClient->getSdkVersion();
+        } else {
+            $serviceLibSdkVersion = "graph-php/".$this->graphClient->getSdkVersion();
+        }
         if (NationalCloud::containsNationalCloudHost($this->requestUri)) {
             $this->headers = [
                 'Content-Type' => 'application/json',

--- a/tests/Http/Request/GraphRequestTest.php
+++ b/tests/Http/Request/GraphRequestTest.php
@@ -91,12 +91,24 @@ class GraphRequestTest extends BaseGraphRequestTest
     public function testConstructorSetsExpectedHeadersGivenValidGraphBaseUrl(): void {
         $expectedHeaders = [
             'Content-Type' => ['application/json'],
-            'SdkVersion' => ["graph-php-core/".GraphConstants::SDK_VERSION.", Graph-php-".$this->mockGraphClient->getSdkVersion()],
+            'SdkVersion' => ["graph-php-core/".GraphConstants::SDK_VERSION.", graph-php/".$this->mockGraphClient->getSdkVersion()],
             'Authorization' => ['Bearer ' . $this->mockGraphClient->getAccessToken()],
             'Host' => [substr($this->mockGraphClient->getNationalCloud(), strlen("https://"))]
         ];
         $request = new GraphRequest("GET", "/me", $this->mockGraphClient);
         $this->assertEquals($expectedHeaders, $request->getHeaders());
+    }
+
+    public function testConstructorSetsExpectedBetaSdkVersionHeader(): void {
+        $graphClient = $this->createMock(AbstractGraphClient::class);
+        $graphClient->method('getAccessToken')->willReturn("abc");
+        $graphClient->method('getNationalCloud')->willReturn(NationalCloud::GLOBAL);
+        $graphClient->method('getSdkVersion')->willReturn('2.0.0');
+        $graphClient->method('getApiVersion')->willReturn(GraphConstants::BETA_API_VERSION);
+
+        $request = new GraphRequest("GET", "/me", $graphClient);
+        $expected = ["graph-php-core/".GraphConstants::SDK_VERSION.", graph-php-beta/".$graphClient->getSdkVersion()];
+        $this->assertEquals($expected, $request->getHeaders()["SdkVersion"]);
     }
 
     public function testConstructorSetsExpectedHeadersGivenValidCustomBaseUrl(): void {
@@ -113,7 +125,7 @@ class GraphRequestTest extends BaseGraphRequestTest
         $endpoint = "https://graph.microsoft.com/v1.0/me/users\$skip=10&\$top=5";
         $expectedHeaders = [
             'Content-Type' => ['application/json'],
-            'SdkVersion' => ["graph-php-core/".GraphConstants::SDK_VERSION.", Graph-php-".$this->mockGraphClient->getSdkVersion()],
+            'SdkVersion' => ["graph-php-core/".GraphConstants::SDK_VERSION.", graph-php/".$this->mockGraphClient->getSdkVersion()],
             'Authorization' => ['Bearer ' . $this->mockGraphClient->getAccessToken()],
             'Host' => [substr($this->mockGraphClient->getNationalCloud(), strlen("https://"))]
         ];


### PR DESCRIPTION
Changes SDK version header from `Graph-php-[major.minor.build]` to match [SDK guidelines](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/middleware/TelemetryHandler.md#requirements) i.e. `graph-php/[major.minor.build]` and `graph-php-beta/[major.minor.build]`