### PR TITLE
Fix static analysis issues

### DIFF
--- a/src/Exception/BaseErrorContent.php
+++ b/src/Exception/BaseErrorContent.php
@@ -43,10 +43,10 @@ class BaseErrorContent
     /**
      * Returns value of $property in $propDict
      *
-     * @param $property
+     * @param string $property
      * @return mixed|null
      */
-    protected function getProperty($property) {
+    protected function getProperty(string $property) {
         if (array_key_exists($property, $this->propDict)) {
             return $this->propDict[$property];
         }

--- a/src/Exception/GraphErrorContent.php
+++ b/src/Exception/GraphErrorContent.php
@@ -59,7 +59,10 @@ class GraphErrorContent extends ODataErrorContent
         $errorString .= ($this->getCode()) ? "\nCode: ".$this->getCode() : "";
         $errorString .= ($this->getMessage()) ? "\nMessage: ".$this->getMessage() : "";
         $errorString .= ($this->getTarget()) ? "\nTarget: ".$this->getTarget() : "";
-        $errorString .= ($this->getDetails()) ? "\nDetails: ".$this->getDetails() : "";
+        if ($this->getDetails()) {
+            $details = array_map(function ($detail) { return strval($detail); }, $this->getDetails());
+            $errorString .= implode(",", $details);
+        }
         $errorString .= ($this->getInnerError()) ? "\nInner Error: ".$this->getInnerError() : "";
         return $errorString;
     }

--- a/src/Exception/ODataErrorContent.php
+++ b/src/Exception/ODataErrorContent.php
@@ -79,7 +79,10 @@ class ODataErrorContent extends BaseErrorContent
         $errorString = ($this->getCode()) ? "Code: ".$this->getCode() : "";
         $errorString .= ($this->getMessage()) ? "\nMessage: ".$this->getMessage() : "";
         $errorString .= ($this->getTarget()) ? "\nTarget: ".$this->getTarget() : "";
-        $errorString .= ($this->getDetails()) ? "\nDetails: ".$this->getDetails() : "";
+        if ($this->getDetails()) {
+            $details = array_map(function ($detail) { return strval($detail); }, $this->getDetails());
+            $errorString .= implode(",", $details);
+        }
         $errorString .= ($this->getInnerError()) ? "\nInner Error: ".$this->getInnerError() : "";
         return $errorString;
     }

--- a/src/Http/GraphCollectionRequest.php
+++ b/src/Http/GraphCollectionRequest.php
@@ -85,7 +85,7 @@ class GraphCollectionRequest extends GraphRequest
 	 * Gets the number of entries in the collection
 	 *
 	 * @return int|null the number of entries | null if @odata.count doesn't exist for that collection
-     * @throws ClientExceptionInterface if an errors occurs while making the request
+     * @throws ClientExceptionInterface if an error occurs while making the request
      * @throws GraphClientException containing error payload if 4xx response is returned.
      * @throws GraphServiceException containing error payload if 5xx response is returned.
      */
@@ -99,7 +99,7 @@ class GraphCollectionRequest extends GraphRequest
         $this->returnType = null;
         $result = $this->execute();
         $this->returnType = $this->originalReturnType;
-        return ($result->getCount()) ?: null;
+        return ($result->getCount()) ?: null; // @phpstan-ignore-line
     }
 
     /**

--- a/src/Task/PageIterator.php
+++ b/src/Task/PageIterator.php
@@ -220,16 +220,16 @@ class PageIterator
             $request = $request->addHeaders($this->requestOptions->getHeaders());
         }
         $this->collectionResponse = $request->execute();
-        if (!$this->collectionResponse || empty($this->collectionResponse->getBody()) || !array_key_exists("value", $this->collectionResponse->getBody())) {
+        if (!$this->collectionResponse || empty($this->collectionResponse->getBody()) || !array_key_exists("value", $this->collectionResponse->getBody())) { // @phpstan-ignore-line
             $this->entityCollection = [];
             return;
         }
         if (!$this->returnType) {
-            if (array_key_exists("value", $this->collectionResponse->getBody())) {
-                $this->entityCollection = $this->collectionResponse->getBody()["value"];
+            if (array_key_exists("value", $this->collectionResponse->getBody())) { // @phpstan-ignore-line
+                $this->entityCollection = $this->collectionResponse->getBody()["value"]; // @phpstan-ignore-line
                 return;
             }
         }
-        $this->entityCollection = $this->collectionResponse->getResponseAsObject($this->returnType);
+        $this->entityCollection = $this->collectionResponse->getResponseAsObject($this->returnType); // @phpstan-ignore-line
     }
 }


### PR DESCRIPTION
Fixes issues identified during static analysis run on https://github.com/microsoftgraph/msgraph-sdk-php-core/pull/33/checks?check_run_id=3672933350

### Decision to ignore PHPStan issues on specific `GraphCollectionRequest` and `PageIterator` lines
`GraphCollectionRequest` and `PageIterator` issues identified are a result of the `execute()` method returning multiple types.
We could choose to validate the returned object is a `GraphResponse` before calling `GraphResponse` methods (`getCount(), getBody()` etc). I feel this is unnecessary since:
- we are in control of the configuration of the GraphRequest to guarantee us a GraphResponse object as a response
- we have tests that catch this should the return type change
- if we assert the response type, should we throw an exception to the customer?

Opted to ignore the warnings for reasons 1 & 2 above & not seeing the benefit of making the customer handle another possible exception that's unlikely to happen in their code