### PR TITLE
Update sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To install the `microsoft-graph-core` library with Composer, either run `compose
 ```
 {
     "require": {
-        "microsoft/microsoft-graph-core": "^2.0.0-preview.1"
+        "microsoft/microsoft-graph-core": "^2.0.0-RC1"
     }
 }
 ```

--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -25,7 +25,7 @@ final class GraphConstants
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 
     // Define HTTP request constants
-    const SDK_VERSION = "2.0.0-preview.1";
+    const SDK_VERSION = "2.0.0-RC1";
 
     // Define error constants
     const MAX_PAGE_SIZE = 999;


### PR DESCRIPTION
Composer considers the preview suffix to be an INVALID version constraint. The RC suffix convention works as expected.