### PR TITLE
Support overwriting existing headers & response exception updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To install the `microsoft-graph-core` library with Composer, either run `compose
 ```
 {
     "require": {
-        "microsoft/microsoft-graph-core": "^2.0.0-RC2"
+        "microsoft/microsoft-graph-core": "^2.0.0-RC3"
     }
 }
 ```

--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -25,7 +25,7 @@ final class GraphConstants
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 
     // Define HTTP request constants
-    const SDK_VERSION = "2.0.0-RC2";
+    const SDK_VERSION = "2.0.0-RC3";
 
     // Define error constants
     const MAX_PAGE_SIZE = 999;

--- a/src/Exception/GraphResponseException.php
+++ b/src/Exception/GraphResponseException.php
@@ -9,6 +9,7 @@
 namespace Microsoft\Graph\Exception;
 
 use Microsoft\Graph\Http\GraphRequest;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Class GraphServiceException
@@ -35,11 +36,17 @@ class GraphResponseException extends \Exception
      */
     private $responseStatusCode;
     /**
-     * JSON-decoded response body
+     * Raw response body
+     *
+     * @var StreamInterface
+     */
+    private $responseStream;
+    /**
+     * JSON_decoded response body
      *
      * @var array
      */
-    private $responseBody;
+    private $jsonBody = [];
     /**
      * The request that triggered the error response
      *
@@ -52,20 +59,20 @@ class GraphResponseException extends \Exception
      * GraphServiceException constructor.
      * @param GraphRequest $graphRequest
      * @param int $responseStatusCode
-     * @param array $responseBody
+     * @param StreamInterface $responseStream
      * @param array $responseHeaders
      */
     public function __construct(
-        GraphRequest $graphRequest,
-        int $responseStatusCode,
-        array $responseBody,
-        array $responseHeaders
+        GraphRequest    $graphRequest,
+        int             $responseStatusCode,
+        StreamInterface $responseStream,
+        array           $responseHeaders
     ) {
         $this->graphRequest = $graphRequest;
         $this->responseStatusCode = $responseStatusCode;
-        $this->responseBody = $responseBody;
+        $this->responseStream = $responseStream;
         $this->responseHeaders = $responseHeaders;
-        $message = "'".$graphRequest->getRequestType()."' request to ".$graphRequest->getRequestUri()." returned ".$responseStatusCode."\n".json_encode($responseBody);
+        $message = "'".$graphRequest->getRequestType()."' request to ".$graphRequest->getRequestUri()." returned ".$responseStatusCode;
         parent::__construct($message, $responseStatusCode);
     }
 
@@ -88,12 +95,36 @@ class GraphResponseException extends \Exception
     }
 
     /**
-     * Get JSON-decoded response payload from the Graph
+     * Returns the raw response stream
      *
-     * @return array
+     * @return StreamInterface
      */
-    public function getRawResponseBody(): array {
-        return $this->responseBody;
+    public function getRawResponseBody(): StreamInterface {
+        return $this->responseStream;
+    }
+
+    /**
+     * Get the response stream contents
+     *
+     * @return string
+     */
+    public function getResponseBodyAsString(): string {
+        $this->responseStream->rewind();
+        return $this->responseStream->getContents();
+    }
+
+    /**
+     * Returns the JSON-decoded response payload from the Graph
+     * If payload could not be JSON-decoded, consider getResponseBodyString() or getRawResponseBody()
+     *
+     * @return array|null
+     */
+    public function getResponseBodyJson(): ?array {
+        if (!$this->jsonBody) {
+            $this->responseStream->rewind();
+            $this->jsonBody = json_decode($this->responseStream->getContents(), true);
+        }
+        return $this->jsonBody;
     }
 
     /**
@@ -102,8 +133,8 @@ class GraphResponseException extends \Exception
      * @return ODataErrorContent|null
      */
     public function getError(): ?ODataErrorContent {
-        if (array_key_exists("error", $this->responseBody)) {
-            return new ODataErrorContent($this->responseBody["error"]);
+        if (array_key_exists("error", $this->jsonBody)) {
+            return new ODataErrorContent($this->jsonBody["error"]);
         }
         return null;
     }

--- a/src/Exception/GraphResponseException.php
+++ b/src/Exception/GraphResponseException.php
@@ -44,9 +44,9 @@ class GraphResponseException extends \Exception
     /**
      * JSON_decoded response body
      *
-     * @var array
+     * @var array|null
      */
-    private $jsonBody = [];
+    private $jsonBody;
     /**
      * The request that triggered the error response
      *
@@ -105,9 +105,10 @@ class GraphResponseException extends \Exception
     }
 
     /**
-     * Get the response stream contents
+     * Get the response stream contents as a string
      *
      * @return string
+     * @throws \RuntimeException if the stream couldn't be read/rewind() failed
      */
     public function getResponseBodyAsString(): string {
         $this->responseStream->rewind();
@@ -116,7 +117,7 @@ class GraphResponseException extends \Exception
 
     /**
      * Returns the JSON-decoded response payload from the Graph
-     * If payload could not be JSON-decoded, consider getResponseBodyAsString() or getRawResponseBody()
+     * If payload could not be JSON-decoded null is returned. Consider getResponseBodyAsString() or getRawResponseBody()
      *
      * @return array|null
      */
@@ -178,6 +179,10 @@ class GraphResponseException extends \Exception
      */
     private function setJsonBody(): void {
         $this->responseStream->rewind();
-        $this->jsonBody = json_decode($this->responseStream->getContents(), true);
+        try {
+            $this->jsonBody = json_decode($this->responseStream->getContents(), true);
+        } catch (\RuntimeException $ex) {
+            $this->jsonBody = null;
+        }
     }
 }

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -183,8 +183,7 @@ class GraphRequest
      */
     public function addHeaders(array $headers): self
     {
-        // Recursive merge to support appending values to multi-value headers
-        $this->headers = array_merge_recursive($this->headers, $headers);
+        $this->headers = array_merge($this->headers, $headers);
         $this->initPsr7HttpRequest();
         return $this;
     }

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -438,7 +438,7 @@ class GraphRequest
             throw new GraphServiceException(
                 $this,
                 $httpResponse->getStatusCode(),
-                json_decode($httpResponse->getBody(), true),
+                $httpResponse->getBody(),
                 $httpResponse->getHeaders()
             );
         }
@@ -446,7 +446,7 @@ class GraphRequest
             throw new GraphClientException(
                 $this,
                 $httpResponse->getStatusCode(),
-                json_decode($httpResponse->getBody(), true),
+                $httpResponse->getBody(),
                 $httpResponse->getHeaders()
             );
         }

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -99,8 +99,8 @@ class GraphRequest
      */
     public function __construct(string $requestType, string $endpoint, AbstractGraphClient $graphClient, string $baseUrl = "")
     {
-        if (!$requestType || !$endpoint || !$graphClient) {
-            throw new \InvalidArgumentException("Request type, endpoint and client cannot be null or empty");
+        if (!$requestType || !$endpoint) {
+            throw new \InvalidArgumentException("Request type and endpoint cannot be null or empty");
         }
         if (!$graphClient->getAccessToken()) {
             throw new \InvalidArgumentException(GraphConstants::NO_ACCESS_TOKEN);

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -175,7 +175,7 @@ class GraphRequest
     }
 
     /**
-     * Adds custom headers to the request
+     * Adds custom headers to the request. Overwrites existing header names
      *
      * @param array<string, string|string[]> $headers An array of custom headers
      *

--- a/tests/Exception/GraphResponseExceptionTest.php
+++ b/tests/Exception/GraphResponseExceptionTest.php
@@ -10,16 +10,18 @@ namespace Microsoft\Graph\Test\Exception;
 
 
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Microsoft\Graph\Exception\GraphResponseException;
 use Microsoft\Graph\Exception\ODataErrorContent;
 use Microsoft\Graph\Http\GraphRequest;
 use Microsoft\Graph\Test\Http\SampleGraphResponsePayload;
+use Psr\Http\Message\StreamInterface;
 
 class GraphResponseExceptionTest extends \PHPUnit\Framework\TestCase
 {
     private $mockGraphRequest;
     private $responseStatusCode = 404;
-    private $responseBody = SampleGraphResponsePayload::ERROR_PAYLOAD;
+    private $responseBody;
     private $responseHeaders = [
         "Content-Type" => "application/json",
         "request-id" => "2f91ee0a-e013-425b-a5bf-b1f251163969",
@@ -29,12 +31,13 @@ class GraphResponseExceptionTest extends \PHPUnit\Framework\TestCase
     private $psr7Response;
 
     protected function setUp(): void {
+        $this->responseBody = Utils::streamFor(json_encode(SampleGraphResponsePayload::ERROR_PAYLOAD));
         $this->mockGraphRequest = $this->createMock(GraphRequest::class);
-        $this->psr7Response = new Response($this->responseStatusCode, $this->responseHeaders, json_encode($this->responseBody));
+        $this->psr7Response = new Response($this->responseStatusCode, $this->responseHeaders, $this->responseBody);
         $this->defaultException = new GraphResponseException(
             $this->mockGraphRequest,
             $this->psr7Response->getStatusCode(),
-            json_decode($this->psr7Response->getBody(), true),
+            $this->psr7Response->getBody(),
             $this->psr7Response->getHeaders()
         );
     }
@@ -46,9 +49,26 @@ class GraphResponseExceptionTest extends \PHPUnit\Framework\TestCase
     public function testGetters(): void {
         $this->assertEquals($this->mockGraphRequest, $this->defaultException->getRequest());
         $this->assertEquals($this->responseStatusCode, $this->defaultException->getResponseStatusCode());
-        $this->assertEquals($this->responseBody, $this->defaultException->getRawResponseBody());
+        $this->assertInstanceOf(StreamInterface::class, $this->defaultException->getRawResponseBody());
+        $this->assertEquals(SampleGraphResponsePayload::ERROR_PAYLOAD, $this->defaultException->getResponseBodyJson());
+        $this->assertEquals(json_encode(SampleGraphResponsePayload::ERROR_PAYLOAD), $this->defaultException->getResponseBodyAsString());
         $this->assertEquals($this->psr7Response->getHeaders(), $this->defaultException->getResponseHeaders());
         $this->assertInstanceOf(ODataErrorContent::class, $this->defaultException->getError());
+    }
+
+    public function testGettersWithStringResponsePayload(): void {
+        $responseBody = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd"> <HTML><HEAD><TITLE>Bad Request</TITLE> <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD> <BODY><h2>Bad Request - Invalid Header</h2> <hr><p>HTTP Error 400. The request has an invalid header name.</p> </BODY></HTML>';
+        $responseException = new GraphResponseException(
+            $this->mockGraphRequest,
+            $this->psr7Response->getStatusCode(),
+            Utils::streamFor($responseBody),
+            $this->psr7Response->getHeaders()
+        );
+
+        $this->assertInstanceOf(StreamInterface::class, $responseException->getRawResponseBody());
+        $this->assertNull($responseException->getResponseBodyJson());
+        $this->assertEquals($responseBody, $responseException->getResponseBodyAsString());
+
     }
 
     public function testGetClientRequestId(): void {

--- a/tests/Http/Request/GraphRequestTest.php
+++ b/tests/Http/Request/GraphRequestTest.php
@@ -185,10 +185,10 @@ class GraphRequestTest extends BaseGraphRequestTest
         $this->assertEquals($values, $this->defaultGraphRequest->getHeaders()['Accept-Language']);
     }
 
-    public function testAddHeadersWithExistingHeaderNameDoesCaseSensitiveAppend(): void {
+    public function testAddHeadersWithExistingHeaderNameOverwrites(): void {
         $this->assertEquals('application/json', $this->defaultGraphRequest->getHeaders()['Content-Type']);
         $this->defaultGraphRequest->addHeaders(['Content-Type' => 'text']);
-        $this->assertEquals(["application/json", "text"], $this->defaultGraphRequest->getHeaders()['Content-Type']);
+        $this->assertEquals("text", $this->defaultGraphRequest->getHeaders()['Content-Type']);
     }
 
     public function testAttachBodyReturnsGraphRequestInstance(): void {


### PR DESCRIPTION
Changes:
- Use `array_merge` to allow customers to overwrite our default header values. Appending values will be at the discretion of the developer
- Support string response payloads from the Graph for 4xx/5xx errors. We had only anticipated JSON payloads from the Graph

Some breaking changes here:
- `GraphResponseException` takes in a `StreamInterface` as opposed to an array
- `getRawResponseBody()` return type changes from `array` to `StreamInterface`

Closes #53 
Closes #54