### PR TITLE
Fix PHPStan errors in BatchRequest and PageIterator

### DIFF
--- a/src/Requests/BaseBatchRequestBuilder.php
+++ b/src/Requests/BaseBatchRequestBuilder.php
@@ -17,6 +17,7 @@ use Microsoft\Kiota\Abstractions\Serialization\Parsable;
 
 /**
  * Class BaseBatchRequestBuilder
+ * @template T of Parsable
  * @package Microsoft\Graph\Core\Requests
  * @copyright 2023 Microsoft Corporation
  * @license https://opensource.org/licenses/MIT MIT License
@@ -30,7 +31,6 @@ class BaseBatchRequestBuilder
     private RequestAdapter $requestAdapter;
 
     /**
-     * @template T of Parsable
      * @var array<string, array{class-string<T>, string}>|null Error models per status code range to deserialize
      *  failed batch request payloads to
      * e.g. ['4XX' => [Parsable that extends ApiException, static factory method in error model]]
@@ -44,7 +44,7 @@ class BaseBatchRequestBuilder
 
     /**
      * @param RequestAdapter $requestAdapter
-     * @param array<string, array{string, string}>|null $errorMappings
+     * @param array<string, array{class-string<T>, string}>|null $errorMappings
      */
     public function __construct(RequestAdapter $requestAdapter, array $errorMappings = null)
     {

--- a/src/Requests/BaseBatchRequestBuilder.php
+++ b/src/Requests/BaseBatchRequestBuilder.php
@@ -13,6 +13,7 @@ use Http\Promise\RejectedPromise;
 use Microsoft\Kiota\Abstractions\HttpMethod;
 use Microsoft\Kiota\Abstractions\RequestAdapter;
 use Microsoft\Kiota\Abstractions\RequestInformation;
+use Microsoft\Kiota\Abstractions\Serialization\Parsable;
 
 /**
  * Class BaseBatchRequestBuilder
@@ -29,7 +30,8 @@ class BaseBatchRequestBuilder
     private RequestAdapter $requestAdapter;
 
     /**
-     * @var array<string, array{string, string}>|null Error models per status code range to deserialize
+     * @template T of Parsable
+     * @var array<string, array{class-string<T>, string}>|null Error models per status code range to deserialize
      *  failed batch request payloads to
      * e.g. ['4XX' => [Parsable that extends ApiException, static factory method in error model]]
      */

--- a/src/Requests/BatchRequestBuilderPostRequestConfiguration.php
+++ b/src/Requests/BatchRequestBuilderPostRequestConfiguration.php
@@ -21,7 +21,7 @@ use Microsoft\Kiota\Abstractions\RequestOption;
 class BatchRequestBuilderPostRequestConfiguration
 {
     /**
-     * @var array<string, string>|null $headers Request headers
+     * @var array<string, array<string>|string>|null $headers Request headers
      */
     public ?array $headers = null;
 

--- a/src/Requests/BatchResponseContent.php
+++ b/src/Requests/BatchResponseContent.php
@@ -68,10 +68,11 @@ class BatchResponseContent implements Parsable
     /**
      * Deserializes a response item's body to $type. $type MUST implement Parsable
      *
+     * @template T of Parsable
      * @param string $requestId
-     * @param string $type Parsable class name
+     * @param class-string<T> $type Parsable class name
      * @param ParseNodeFactory|null $parseNodeFactory checks the ParseNodeFactoryRegistry by default
-     * @return Parsable|null
+     * @return T|null
      */
     public function getResponseBody(string $requestId, string $type, ?ParseNodeFactory $parseNodeFactory = null): ?Parsable
     {
@@ -104,7 +105,6 @@ class BatchResponseContent implements Parsable
     public function getFieldDeserializers(): array
     {
         return [
-            /** @phpstan-ignore-next-line */
             'responses' => fn (ParseNode $n) => $this->setResponses($n->getCollectionOfObjectValues([BatchResponseItem::class, 'create']))
         ];
     }

--- a/src/Requests/BatchResponseContent.php
+++ b/src/Requests/BatchResponseContent.php
@@ -30,26 +30,30 @@ use UnexpectedValueException;
 class BatchResponseContent implements Parsable
 {
     /**
-     * @var array<string, BatchResponseItem>
+     * @var array<string, BatchResponseItem>|null
      */
-    private array $responses = [];
+    private ?array $responses = [];
 
     public function __construct() {}
 
     /**
-     * @return BatchResponseItem[]
+     * @return BatchResponseItem[]|null
      */
-    public function getResponses(): array
+    public function getResponses(): ?array
     {
-        return array_values($this->responses);
+        return is_null($this->responses) ? null : array_values($this->responses);
     }
 
     /**
-     * @param BatchResponseItem[] $responses
+     * @param BatchResponseItem[]|null $responses
      */
-    public function setResponses(array $responses): void
+    public function setResponses(?array $responses): void
     {
-        array_map(fn ($response) => $this->responses[$response->getId()] = $response, $responses);
+        if (is_array($responses)) {
+            array_map(fn ($response) => $this->responses[$response->getId()] = $response, $responses);
+            return;
+        }
+        $this->responses = $responses;
     }
 
     /**
@@ -59,7 +63,7 @@ class BatchResponseContent implements Parsable
      */
     public function getResponse(string $requestId): BatchResponseItem
     {
-        if (!array_key_exists($requestId, $this->responses)) {
+        if (!$this->responses || !array_key_exists($requestId, $this->responses)) {
             throw new InvalidArgumentException("No response found for id: {$requestId}");
         }
         return $this->responses[$requestId];
@@ -76,7 +80,7 @@ class BatchResponseContent implements Parsable
      */
     public function getResponseBody(string $requestId, string $type, ?ParseNodeFactory $parseNodeFactory = null): ?Parsable
     {
-        if (!array_key_exists($requestId, $this->responses)) {
+        if (!$this->responses || !array_key_exists($requestId, $this->responses)) {
             throw new InvalidArgumentException("No response found for id: {$requestId}");
         }
         $interfaces = class_implements($type);

--- a/src/Tasks/PageIterator.php
+++ b/src/Tasks/PageIterator.php
@@ -16,13 +16,18 @@ use Microsoft\Kiota\Abstractions\RequestInformation;
 use Microsoft\Kiota\Abstractions\RequestOption;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;
 
+/**
+ * @template T of Parsable
+ */
 class PageIterator
 {
     private PageResult $currentPage;
     private RequestAdapter $requestAdapter;
     private bool $hasNext = false;
     private int $pauseIndex;
-    /** @var array{string, string} $constructorCallable */
+    /**
+     * @var array{class-string<T>, string} $constructorCallable
+    */
     private array $constructorCallable;
     /** @var RequestHeaders */
     private RequestHeaders $headers;
@@ -32,7 +37,7 @@ class PageIterator
     /**
      * @param Parsable|array<mixed>|object|null $response paged collection response
      * @param RequestAdapter $requestAdapter
-     * @param array{string,string} $constructorCallable The method to construct a paged response object.
+     * @param array{class-string<T>,string} $constructorCallable The method to construct a paged response object.
      * @throws JsonException
      */
     public function __construct($response, RequestAdapter $requestAdapter, array $constructorCallable)


### PR DESCRIPTION
Following updating PHPDocs in Kiota Abstractions to accept generics, the BatchRequest and PageIterator needed to reflect the same changes