### PR TITLE
Fix Batch Request bugs

### DIFF
--- a/src/Requests/BatchRequestItem.php
+++ b/src/Requests/BatchRequestItem.php
@@ -16,6 +16,7 @@ use Microsoft\Kiota\Abstractions\Serialization\SerializationWriter;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Ramsey\Uuid\Uuid;
+use RuntimeException;
 
 /**
  * Class BatchRequestItem
@@ -131,7 +132,12 @@ class BatchRequestItem implements Parsable
             throw new \InvalidArgumentException("Invalid URL {$url}");
         }
         // Set relative URL
-        $this->url = "{$urlParts['path']}";
+        // Remove API version
+        $urlWithoutVersion = preg_replace("/\/(v1.0|beta)/", '',"{$urlParts['path']}");
+        if (!$urlWithoutVersion) {
+            throw new RuntimeException("Error occurred during regex replacement of API version in URL string: $url");
+        }
+        $this->url = $urlWithoutVersion;
         $this->url .= (array_key_exists('query', $urlParts)) ? "?{$urlParts['query']}" : '';
         $this->url .= (array_key_exists('fragment', $urlParts)) ? "#{$urlParts['fragment']}" : '';
     }

--- a/src/Requests/BatchRequestItem.php
+++ b/src/Requests/BatchRequestItem.php
@@ -239,6 +239,6 @@ class BatchRequestItem implements Parsable
             $headers[$key] = implode(", ", $val);
         }
         $writer->writeAnyValue('headers', $headers);
-        $writer->writeStringValue('body', ($this->getBody()) ? urlencode($this->getBody()->getContents()) : null);
+        $writer->writeAnyValue('body', ($this->getBody()) ? json_decode($this->getBody()->getContents()) : null);
     }
 }

--- a/src/Requests/BatchResponseContent.php
+++ b/src/Requests/BatchResponseContent.php
@@ -10,6 +10,7 @@ namespace Microsoft\Graph\Core\Requests;
 
 use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
+use Microsoft\Kiota\Abstractions\RequestInformation;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNode;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactory;
@@ -88,10 +89,10 @@ class BatchResponseContent implements Parsable
             throw new InvalidArgumentException("Type passed must implement the Parsable interface");
         }
         $response = $this->responses[$requestId];
-        if (!($response->getHeaders()['content-type'] ?? null)) {
+        $contentType = $response->getContentType();
+        if (!$contentType) {
             throw new RuntimeException("Unable to get content-type header in response item");
         }
-        $contentType = $response->getHeaders()['content-type'];
         $responseBody = $response->getBody() ?? Utils::streamFor(null);
         if ($parseNodeFactory) {
             $parseNode = $parseNodeFactory->getRootParseNode($contentType, $responseBody);

--- a/src/Requests/BatchResponseItem.php
+++ b/src/Requests/BatchResponseItem.php
@@ -148,4 +148,20 @@ class BatchResponseItem implements Parsable
     {
         $this->body = $body;
     }
+
+    /**
+     * Case-insensitively checks for Content-Type header key and returns value
+     * @return string|null
+     */
+    public function getContentType(): ?string
+    {
+        if ($this->headers) {
+            foreach ($this->headers as $key => $val) {
+                if (strtolower($key) === 'content-type') {
+                    return $val;
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/Requests/BatchResponseItem.php
+++ b/src/Requests/BatchResponseItem.php
@@ -156,11 +156,8 @@ class BatchResponseItem implements Parsable
     public function getContentType(): ?string
     {
         if ($this->headers) {
-            foreach ($this->headers as $key => $val) {
-                if (strtolower($key) === 'content-type') {
-                    return $val;
-                }
-            }
+            $headers = array_change_key_case($this->headers);
+            return $headers['content-type'] ?? null;
         }
         return null;
     }

--- a/tests/Requests/BatchRequestItemTest.php
+++ b/tests/Requests/BatchRequestItemTest.php
@@ -22,9 +22,9 @@ class BatchRequestItemTest extends TestCase
         $this->requestInformation = new RequestInformation();
         $this->requestInformation->httpMethod = HttpMethod::GET;
         $this->requestInformation->addHeaders(["test" => ["value", "value2"]]);
-        $this->requestInformation->setUri(new Uri('https://graph.microsoft.com/v1/users?$top=2'));
+        $this->requestInformation->setUri(new Uri('https://graph.microsoft.com/v1.0/users?$top=2'));
 
-        $this->psrRequest = new Request(HttpMethod::POST, "https://graph.microsoft.com/v1/users", ["key" => ["value1", "value2"]], Utils::streamFor(json_encode(["key" => "val"])));
+        $this->psrRequest = new Request(HttpMethod::POST, "https://graph.microsoft.com/v1.0/users", ["key" => ["value1", "value2"]], Utils::streamFor(json_encode(["key" => "val"])));
     }
 
 
@@ -35,7 +35,7 @@ class BatchRequestItemTest extends TestCase
         $this->assertNotEmpty($batchRequestItem->getId()); // default ID is set
         $this->assertEquals($this->requestInformation->httpMethod, $batchRequestItem->getMethod());
         $this->assertEquals($this->requestInformation->getHeaders()->getAll(), $batchRequestItem->getHeaders());
-        $this->assertEquals('/v1/users?$top=2', $batchRequestItem->getUrl()); // relative URL is set
+        $this->assertEquals('/users?$top=2', $batchRequestItem->getUrl()); // relative URL is set
     }
 
     public function testCreateWithPsrRequest()
@@ -45,7 +45,7 @@ class BatchRequestItemTest extends TestCase
         $this->assertNotEmpty($batchRequestItem->getId()); // default ID is set
         $this->assertEquals($this->psrRequest->getMethod(), $batchRequestItem->getMethod());
         $this->assertEquals(['host' => ['graph.microsoft.com'], 'key' => ['value1', 'value2']], $batchRequestItem->getHeaders());
-        $this->assertEquals('/v1/users', $batchRequestItem->getUrl()); // relative URL is set
+        $this->assertEquals('/users', $batchRequestItem->getUrl()); // relative URL is set
     }
 
     public function testDependsOn()
@@ -70,7 +70,7 @@ class BatchRequestItemTest extends TestCase
         $expectedJson = json_encode([
             "id" => $batchRequestItem1->getId(),
             "method" => $batchRequestItem1->getMethod(),
-            "url" => '/v1/users',
+            "url" => '/users',
             "dependsOn" => [$batchRequestItem2->getId(), $batchRequestItem3->getId()],
             "headers" => ['host' => 'graph.microsoft.com', 'key' => 'value1, value2'],
             "body" => urlencode($this->psrRequest->getBody()->getContents())

--- a/tests/Requests/BatchRequestItemTest.php
+++ b/tests/Requests/BatchRequestItemTest.php
@@ -73,7 +73,7 @@ class BatchRequestItemTest extends TestCase
             "url" => '/users',
             "dependsOn" => [$batchRequestItem2->getId(), $batchRequestItem3->getId()],
             "headers" => ['host' => 'graph.microsoft.com', 'key' => 'value1, value2'],
-            "body" => urlencode($this->psrRequest->getBody()->getContents())
+            "body" => ['key' => 'val']
         ], JSON_UNESCAPED_SLASHES);
 
         $this->assertEquals($expectedJson, $jsonSerializationWriter->getSerializedContent()->getContents());

--- a/tests/Requests/BatchResponseContentTest.php
+++ b/tests/Requests/BatchResponseContentTest.php
@@ -15,7 +15,7 @@ class BatchResponseContentTest extends TestCase
     {
         $responseItem = new BatchResponseItem();
         $responseItem->setId('1');
-        $responseItem->setHeaders(['content-type' => 'application/json']);
+        $responseItem->setHeaders(['Content-Type' => 'application/json']);
         $responseItem->setBody(Utils::streamFor(json_encode([
             'id' => '123',
             'name' => 'xyz'


### PR DESCRIPTION
Batch requests would fail because of wrongly serialized payloads, wrong URL i.e. URL with API version prefix & deserialization issues due to case-sensitive matching of the Content-Type header

closes https://github.com/microsoftgraph/msgraph-sdk-php-core/issues/88