### PR TITLE
Batch Request Serialization bug fixes

### DIFF
--- a/src/Requests/BatchRequestItem.php
+++ b/src/Requests/BatchRequestItem.php
@@ -240,7 +240,7 @@ class BatchRequestItem implements Parsable
         }
         $writer->writeAnyValue('headers', $headers);
         if ($this->getBody()) {
-            // API expects JSON object or base 64 URL encoded value for the body
+            // API expects JSON object or base 64 encoded value for the body
             // We JSON decode the stream contents so that the body is not written as a string
             $jsonObject = json_decode($this->getBody()->getContents(), true);
             $isJsonString = $jsonObject && (json_last_error() === JSON_ERROR_NONE);

--- a/src/Requests/BatchResponseContent.php
+++ b/src/Requests/BatchResponseContent.php
@@ -100,8 +100,11 @@ class BatchResponseContent implements Parsable
             // Check the registry or default to Json deserialization
             try {
                 $parseNode = ParseNodeFactoryRegistry::getDefaultInstance()->getRootParseNode($contentType, $responseBody);
-            } catch (UnexpectedValueException $ex) {
-                $parseNode = (new JsonParseNodeFactory())->getRootParseNode($contentType, $responseBody);
+            } catch (\Exception $ex) {
+                $responseBody->rewind();
+                $response->setBody(Utils::streamFor(base64_decode($responseBody->getContents())));
+                $responseBody = $response->getBody() ?? Utils::streamFor(null);
+                $parseNode = ParseNodeFactoryRegistry::getDefaultInstance()->getRootParseNode($contentType, $responseBody);
             }
         }
         return $parseNode->getObjectValue([$type, 'createFromDiscriminatorValue']);

--- a/tests/Requests/BatchRequestContentTest.php
+++ b/tests/Requests/BatchRequestContentTest.php
@@ -7,23 +7,29 @@ use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Utils;
 use Microsoft\Graph\Core\Requests\BatchRequestContent;
 use Microsoft\Graph\Core\Requests\BatchRequestItem;
+use Microsoft\Kiota\Abstractions\RequestAdapter;
 use Microsoft\Kiota\Abstractions\RequestInformation;
 use Microsoft\Kiota\Serialization\Json\JsonSerializationWriter;
+use Microsoft\Kiota\Serialization\Json\JsonSerializationWriterFactory;
 use PHPUnit\Framework\TestCase;
 
 class BatchRequestContentTest extends TestCase
 {
     private array $requests;
     private RequestInformation $requestInformation;
+    private RequestAdapter $mockRequestAdapter;
 
     protected function setUp(): void
     {
         $this->requestInformation = new RequestInformation();
         $this->requestInformation->httpMethod = "POST";
         $this->requestInformation->setUri(new Uri("/v1/users"));
-        $this->requestInformation->setStreamContent(Utils::streamFor('{"key": "value"}'));
+        $this->requestInformation->setStreamContent(Utils::streamFor("Hello world!"));
 
         $this->requests = [$this->requestInformation, $this->requestInformation, $this->requestInformation];
+
+        $this->mockRequestAdapter = $this->createStub(RequestAdapter::class);
+        $this->mockRequestAdapter->method('getSerializationWriterFactory')->willReturn((new JsonSerializationWriterFactory()));
     }
 
     public function testConstructor()
@@ -77,7 +83,7 @@ class BatchRequestContentTest extends TestCase
         $this->assertEmpty($requestContext->getRequests());
     }
 
-    public function testSerialization()
+    public function testSerializationWithNonJsonBody()
     {
         $this->requestInformation->addHeaders(['accept' => 'application/json']);
         $batchRequestContent = new BatchRequestContent([$this->requestInformation]);
@@ -92,7 +98,30 @@ class BatchRequestContentTest extends TestCase
                     "method" => $this->requestInformation->httpMethod,
                     "url" => '/v1/users',
                     'headers' => ['content-type' => 'application/octet-stream', 'accept' => 'application/json'],
-                    "body" => ['key' => 'value']
+                    "body" => base64_encode("Hello world!")
+                ]
+            ]
+        ], JSON_UNESCAPED_SLASHES);
+
+        $this->assertEquals($expectedJson, $serializationWriter->getSerializedContent()->getContents());
+    }
+
+    public function testSerializationWithJsonBody()
+    {
+        $this->requestInformation->setContentFromParsable($this->mockRequestAdapter, 'application/json', new TestUserModel('1', '1'));
+        $batchRequestContent = new BatchRequestContent([$this->requestInformation]);
+
+        $serializationWriter = new JsonSerializationWriter();
+        $serializationWriter->writeObjectValue(null, $batchRequestContent);
+
+        $expectedJson = json_encode([
+            'requests' => [
+                [
+                    "id" => $batchRequestContent->getRequests()[0]->getId(),
+                    "method" => $this->requestInformation->httpMethod,
+                    "url" => '/v1/users',
+                    'headers' => ['content-type' => 'application/octet-stream, application/json'],
+                    "body" => ["id" => "1", "name" => "1"]
                 ]
             ]
         ], JSON_UNESCAPED_SLASHES);

--- a/tests/Requests/BatchRequestContentTest.php
+++ b/tests/Requests/BatchRequestContentTest.php
@@ -21,7 +21,7 @@ class BatchRequestContentTest extends TestCase
         $this->requestInformation = new RequestInformation();
         $this->requestInformation->httpMethod = "POST";
         $this->requestInformation->setUri(new Uri("/v1/users"));
-        $this->requestInformation->setStreamContent(Utils::streamFor("abcd"));
+        $this->requestInformation->setStreamContent(Utils::streamFor('{"key": "value"}'));
 
         $this->requests = [$this->requestInformation, $this->requestInformation, $this->requestInformation];
     }
@@ -92,7 +92,7 @@ class BatchRequestContentTest extends TestCase
                     "method" => $this->requestInformation->httpMethod,
                     "url" => '/v1/users',
                     'headers' => ['content-type' => 'application/octet-stream', 'accept' => 'application/json'],
-                    "body" => urlencode("abcd")
+                    "body" => ['key' => 'value']
                 ]
             ]
         ], JSON_UNESCAPED_SLASHES);

--- a/tests/Requests/BatchRequestItemTest.php
+++ b/tests/Requests/BatchRequestItemTest.php
@@ -78,4 +78,14 @@ class BatchRequestItemTest extends TestCase
 
         $this->assertEquals($expectedJson, $jsonSerializationWriter->getSerializedContent()->getContents());
     }
+
+    public function testSettingInvalidUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $item = new BatchRequestItem($this->requestInformation);
+        $item->setId('1243');
+        $item->setMethod('GET');
+        $item->setUrl('');
+        $item->setHeaders([]);
+    }
 }

--- a/tests/Requests/BatchResponseContentTest.php
+++ b/tests/Requests/BatchResponseContentTest.php
@@ -5,6 +5,7 @@ namespace Microsoft\Graph\Core\Test\Requests;
 use GuzzleHttp\Psr7\Utils;
 use Microsoft\Graph\Core\Requests\BatchResponseContent;
 use Microsoft\Graph\Core\Requests\BatchResponseItem;
+use Microsoft\Kiota\Abstractions\RequestInformation;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactoryRegistry;
 use Microsoft\Kiota\Serialization\Json\JsonParseNodeFactory;
 use PHPUnit\Framework\TestCase;
@@ -39,5 +40,42 @@ class BatchResponseContentTest extends TestCase
         $this->assertInstanceOf(TestUserModel::class, $response);
         $this->assertEquals('123', $response->getId());
         $this->assertEquals('xyz', $response->getName());
+    }
+
+    public function testGetResponseBodyWithInvalidIdThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->batchResponseContent->getResponse('2');
+    }
+
+    public function testGetResponseBodyThrowsExceptionGivenNonParsableClassName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->batchResponseContent->getResponseBody('1', RequestInformation::class);
+    }
+
+    public function testGetResponseBodyTriesBase64DecodingBeforeFailure(): void
+    {
+        $this->batchResponseContent->getResponse('1')->setBody(
+            Utils::streamFor(base64_encode(json_encode(
+                [
+                    'id' => '123',
+                    'name' => 'xyz'
+                ]
+            )))
+        );
+        $response = $this->batchResponseContent->getResponseBody('1', TestUserModel::class);
+        $this->assertInstanceOf(TestUserModel::class, $response);
+        $this->assertEquals('123', $response->getId());
+        $this->assertEquals('xyz', $response->getName());
+    }
+
+    public function testGetResponseBodyTotalFailureThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->batchResponseContent->getResponse('1')->setBody(
+            Utils::streamFor(base64_encode("{'key':val"))
+        );
+        $response = $this->batchResponseContent->getResponseBody('1', TestUserModel::class);
     }
 }

--- a/tests/Requests/BatchResponseContentTest.php
+++ b/tests/Requests/BatchResponseContentTest.php
@@ -5,6 +5,8 @@ namespace Microsoft\Graph\Core\Test\Requests;
 use GuzzleHttp\Psr7\Utils;
 use Microsoft\Graph\Core\Requests\BatchResponseContent;
 use Microsoft\Graph\Core\Requests\BatchResponseItem;
+use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactoryRegistry;
+use Microsoft\Kiota\Serialization\Json\JsonParseNodeFactory;
 use PHPUnit\Framework\TestCase;
 
 class BatchResponseContentTest extends TestCase
@@ -25,6 +27,8 @@ class BatchResponseContentTest extends TestCase
         ];
         $this->batchResponseContent = new BatchResponseContent();
         $this->batchResponseContent->setResponses($responses);
+        ParseNodeFactoryRegistry::getDefaultInstance()
+            ->contentTypeAssociatedFactories['application/json'] = new JsonParseNodeFactory();
         parent::setUp();
     }
 

--- a/tests/Requests/TestUserModel.php
+++ b/tests/Requests/TestUserModel.php
@@ -19,7 +19,11 @@ class TestUserModel implements Parsable
     private string $id;
     private string $name;
 
-    public function __construct() {}
+    public function __construct(string $id = '', string $name = '')
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
 
     /**
      * @return string


### PR DESCRIPTION
This PR:
- Handles an individual's request body correctly. If it's a JSON object, ensures the stream contents are written as JSON object, else, base 64 encodes stream contents (https://learn.microsoft.com/en-us/graph/json-batching#request-format)
- If initial deserialization fails, retries deserialization after base64 decoding the response body before failing. Indiv. response bodies related to requests which contained base 64 encoded bodies are also base 64 encoded.