### PR TITLE
Remove unused dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 		"microsoft/kiota-serialization-json": "^0.4.0",
 		"microsoft/kiota-serialization-text": "^0.5.0",
 		"php-http/httplug": "^2.2",
-		"php-http/guzzle7-adapter": "^1.0",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,9 @@ parameters:
 	level: 9
 	polluteScopeWithAlwaysIterableForeach: false
 	polluteScopeWithLoopInitialAssignments: false
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+	    - '/^Parameter #1 \$var of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
+	    - '/^Parameter #1 \$value of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
 	paths:
 		- src

--- a/src/GraphClientFactory.php
+++ b/src/GraphClientFactory.php
@@ -10,11 +10,7 @@ namespace Microsoft\Graph\Core;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware as GuzzleMiddleware;
 use GuzzleHttp\RequestOptions;
-use GuzzleHttp\Utils;
-use Http\Adapter\Guzzle7\Client as GuzzleAdapter;
-use Http\Promise\Promise;
 use InvalidArgumentException;
 use Microsoft\Graph\Core\Middleware\GraphMiddleware;
 use Microsoft\Graph\Core\Middleware\GraphRetryHandler;
@@ -22,8 +18,6 @@ use Microsoft\Graph\Core\Middleware\Option\GraphTelemetryOption;
 use Microsoft\Kiota\Http\KiotaClientFactory;
 use Microsoft\Kiota\Http\Middleware\Options\UrlReplaceOption;
 use Microsoft\Kiota\Http\Middleware\RetryHandler;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class GraphClientFactory


### PR DESCRIPTION
Guzzle 7 adapter is not directly used. This lets the Kiota HTTP guzzle lib determine the Guzzle client to be used.