### PR TITLE
Update CODEOWNERS with msgraph-devx-php-write

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ddyett @MichaelMainer @nikithauc @zengin @silaskenneth @Ndiritu @shemogumbe
+* @microsoftgraph/msgraph-devx-php-write


### PR DESCRIPTION
I've removed all individual access grants. All write access now goes through https://github.com/orgs/microsoftgraph/teams/msgraph-devx-php-write team. Please manage code owners through this team.

Admin settings now require JIT admin grant elevation through the Open Source Management Portal.