### PR TITLE
chore: add required status checks

### DIFF
--- a/.github/msgraph-sdk-php-core-branch-protection.yml
+++ b/.github/msgraph-sdk-php-core-branch-protection.yml
@@ -18,7 +18,7 @@ configuration:
     # Specifies whether forced pushes are allowed on this branch. boolean
     allowsForcePushes: false
     # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: false
+    dismissStaleReviews: true
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
     # Indicates whether "Require a pull request before merging" is enabled. boolean
@@ -26,7 +26,7 @@ configuration:
     # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
     requiredApprovingReviewsCount: 1
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: false
+    requireCodeOwnersReview: true
     # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
     requiresCommitSignatures: false
     # Are conversations required to be resolved before merging? boolean
@@ -35,6 +35,8 @@ configuration:
     requiresLinearHistory: false
     # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
+    - validate-pull-request
+    - SonarCloud
     # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
     requiresStrictStatusChecks: true
     # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
@@ -59,7 +61,7 @@ configuration:
     # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
     requiredApprovingReviewsCount: 1
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: false
+    requireCodeOwnersReview: true
     # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
     requiresCommitSignatures: false
     # Are conversations required to be resolved before merging? boolean
@@ -68,6 +70,8 @@ configuration:
     requiresLinearHistory: false
     # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
+    - validate-pull-request
+    - SonarCloud
     # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
     requiresStrictStatusChecks: true
     # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.

--- a/.github/policies/msgraph-sdk-php-core-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-php-core-branch-protection.yml
@@ -9,43 +9,8 @@ resource: repository
 configuration:
   branchProtectionRules:
 
-  - branchNamePattern: main
-    # This branch pattern applies to the following branches as of 06/12/2023 10:31:17:
-    # main
-
-    # Specifies whether this branch can be deleted. boolean
-    allowsDeletions: false
-    # Specifies whether forced pushes are allowed on this branch. boolean
-    allowsForcePushes: false
-    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: true
-    # Specifies whether admins can overwrite branch protection. boolean
-    isAdminEnforced: false
-    # Indicates whether "Require a pull request before merging" is enabled. boolean
-    requiresPullRequestBeforeMerging: true
-    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
-    requiredApprovingReviewsCount: 1
-    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: true
-    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
-    requiresCommitSignatures: false
-    # Are conversations required to be resolved before merging? boolean
-    requiresConversationResolution: true
-    # Are merge commits prohibited from being pushed to this branch. boolean
-    requiresLinearHistory: false
-    # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks:
-    - validate-pull-request
-    - SonarCloud
-    # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
-    requiresStrictStatusChecks: true
-    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
-    restrictsPushes: false
-    # Restrict who can dismiss pull request reviews. boolean
-    restrictsReviewDismissals: false
-
   - branchNamePattern: dev
-    # This branch pattern applies to the following branches as of 06/12/2023 10:31:17:
+    # This branch pattern applies to the following branches as of 08/30/2023:
     # dev
 
     # Specifies whether this branch can be deleted. boolean
@@ -79,3 +44,37 @@ configuration:
     # Restrict who can dismiss pull request reviews. boolean
     restrictsReviewDismissals: false
 
+  - branchNamePattern: main
+    # This branch pattern applies to the following branches as of 08/30/2023:
+    # main
+
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: true
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Indicates whether "Require a pull request before merging" is enabled. boolean
+    requiresPullRequestBeforeMerging: true
+    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: true
+    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
+    requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: true
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusChecks:
+    - validate-pull-request
+    - SonarCloud
+    # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
+    requiresStrictStatusChecks: true
+    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews. boolean
+    restrictsReviewDismissals: false


### PR DESCRIPTION
* Require status checks to pass before merging
* Require code owner approvals of all changes in main/master and dev branches
* Require re-approval after new commits

> **Note**: We must validate this PR after merge by opening another PR to make sure that the required status checks run as expected so that we don't introduce misconfigured blocking policy.