### PR TITLE
Remove sonarcloud from required checks

### DIFF
--- a/.github/policies/msgraph-sdk-php-core-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-php-core-branch-protection.yml
@@ -36,7 +36,7 @@ configuration:
     # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
     - check-php-version-matrix
-    - SonarCloud Code Analysis
+    - license/cla
     # Require branches to be up-to-date before merging. Requires requiredStatusChecks. boolean
     requiresStrictStatusChecks: true
     # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.


### PR DESCRIPTION
SonarCloud does not run on branches from forks leading to failed checks from community contributions e.g. https://github.com/microsoftgraph/msgraph-sdk-php-core/pull/194