### PR TITLE
Deprecate national cloud parameter in access token provider constructor

### DIFF
--- a/src/Authentication/GraphPhpLeagueAuthenticationProvider.php
+++ b/src/Authentication/GraphPhpLeagueAuthenticationProvider.php
@@ -24,13 +24,12 @@ class GraphPhpLeagueAuthenticationProvider extends PhpLeagueAuthenticationProvid
     /**
      * @param TokenRequestContext $tokenRequestContext
      * @param array<string> $scopes defaults to ["https://[graph national cloud host]/.default"] scope
-     * @param string $nationalCloud defaults to https://graph.microsoft.com. See
-     * https://learn.microsoft.com/en-us/graph/deployments
+     * @param string $nationalCloud @deprecated Parameter is not passed up to the parent class. Use createWithAccessTokenProvider() instead
      */
     public function __construct(
         TokenRequestContext $tokenRequestContext,
         array $scopes = [],
-        string $nationalCloud = NationalCloud::GLOBAL
+        string $nationalCloud = NationalCloud::GLOBAL // @deprecated parameter is not passed up to the parent class. Use createWithAccessTokenProvider() instead
     )
     {
         $accessTokenProvider = new GraphPhpLeagueAccessTokenProvider($tokenRequestContext, $scopes, $nationalCloud);

--- a/src/GraphClientFactory.php
+++ b/src/GraphClientFactory.php
@@ -80,7 +80,7 @@ final class GraphClientFactory extends KiotaClientFactory
      * Set national cloud to be used as the base URL
      *
      * @param string $nationalCloud
-     * @return $this
+     * @return static
      * @throws InvalidArgumentException if $nationalCloud is empty or an invalid national cloud Host
      */
     public static function setNationalCloud(string $nationalCloud = NationalCloud::GLOBAL): GraphClientFactory {

--- a/tests/Authentication/GraphPhpLeagueAuthenticationProviderTest.php
+++ b/tests/Authentication/GraphPhpLeagueAuthenticationProviderTest.php
@@ -4,6 +4,7 @@ namespace Microsoft\Graph\Core\Test\Authentication;
 
 use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAccessTokenProvider;
 use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAuthenticationProvider;
+use Microsoft\Graph\Core\NationalCloud;
 use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
 use PHPUnit\Framework\TestCase;
 
@@ -14,5 +15,13 @@ class GraphPhpLeagueAuthenticationProviderTest extends TestCase
         $context = new ClientCredentialContext('tenant', 'clientId', 'secret');
         $leagueAuthProvider = new GraphPhpLeagueAuthenticationProvider($context, []);
         $this->assertNotEmpty($leagueAuthProvider->getAccessTokenProvider()->getAllowedHostsValidator()->getAllowedHosts());
+    }
+
+    public function testNationalCloudUrlIsUsed(): void
+    {
+        $context = new ClientCredentialContext('tenant', 'clientId', 'secret');
+        $leagueAuthProvider = new GraphPhpLeagueAuthenticationProvider($context, [], NationalCloud::US_GOV);
+        $this->assertEquals('https://login.microsoftonline.us/tenant/oauth2/v2.0/authorize', $leagueAuthProvider->getAccessTokenProvider()->getOauthProvider()->getBaseAuthorizationUrl());
+        $this->assertEquals('https://login.microsoftonline.us/tenant/oauth2/v2.0/token', $leagueAuthProvider->getAccessTokenProvider()->getOauthProvider()->getBaseAccessTokenUrl([]));
     }
 }

--- a/tests/Authentication/GraphPhpLeagueAuthenticationProviderTest.php
+++ b/tests/Authentication/GraphPhpLeagueAuthenticationProviderTest.php
@@ -20,7 +20,9 @@ class GraphPhpLeagueAuthenticationProviderTest extends TestCase
     public function testNationalCloudUrlIsUsed(): void
     {
         $context = new ClientCredentialContext('tenant', 'clientId', 'secret');
-        $leagueAuthProvider = new GraphPhpLeagueAuthenticationProvider($context, [], NationalCloud::US_GOV);
+        $leagueAuthProvider = GraphPhpLeagueAuthenticationProvider::createWithAccessTokenProvider(
+            new GraphPhpLeagueAccessTokenProvider($context, [], NationalCloud::US_GOV)
+        );
         $this->assertEquals('https://login.microsoftonline.us/tenant/oauth2/v2.0/authorize', $leagueAuthProvider->getAccessTokenProvider()->getOauthProvider()->getBaseAuthorizationUrl());
         $this->assertEquals('https://login.microsoftonline.us/tenant/oauth2/v2.0/token', $leagueAuthProvider->getAccessTokenProvider()->getOauthProvider()->getBaseAccessTokenUrl([]));
     }


### PR DESCRIPTION
We provided a `$nationalCloud` constructor parameter that is not bubbled up to the parent class.

This PR marks this parameter as deprecated & tests that the static builder method works as expected.

related to https://github.com/microsoftgraph/msgraph-sdk-php/issues/1625

