### PR TITLE
chore: bump Kiota dependencies from ^1.5.0 to ^2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
 	],
 	"require": {
 		"php": "^8.2",
-		"microsoft/kiota-authentication-phpleague": "^1.5.0",
-		"microsoft/kiota-http-guzzle": "^1.5.0",
-		"microsoft/kiota-serialization-json": "^1.5.0",
-		"microsoft/kiota-serialization-text": "^1.5.0",
-		"microsoft/kiota-serialization-form": "^1.5.0",
-		"microsoft/kiota-serialization-multipart": "^1.5.0",
+		"microsoft/kiota-authentication-phpleague": "^2.0.2",
+		"microsoft/kiota-http-guzzle": "^2.0.2",
+		"microsoft/kiota-serialization-json": "^2.0.2",
+		"microsoft/kiota-serialization-text": "^2.0.2",
+		"microsoft/kiota-serialization-form": "^2.0.2",
+		"microsoft/kiota-serialization-multipart": "^2.0.2",
 		"ext-json": "*"
 	},
 	"require-dev": {


### PR DESCRIPTION
## Summary

Bumps all 6 Kiota package constraints from \^1.5.0\ to \^2.0.2\ (major version bump).

## Kiota 2.x Breaking Changes

| Change | Status |
|--------|--------|
| PHP minimum raised to 8.2 | ✅ Already met (\composer.json\ requires \^8.2\) |
| \doctrine/annotations\ removed (native docblock parser) | ⚠️ Low risk — verify no transitive dependency |
| \setQueryParameters()\ now preserves falsy values | ⚠️ Audit query param classes for non-null falsy defaults |
| \amsey/uuid\ requires \^4.2.3\ | ⚠️ Check for conflicts |
| All Kiota packages must be upgraded together | ✅ All 6 bumped in this PR |

## Notes

- Targets **2.0.2** specifically — versions 2.0.0 and 2.0.1 had a regression where \@QueryParameter\ annotations were silently ignored.
- No namespace or class API removals — all Kiota classes/interfaces used by this project remain available.
- Run \composer update\ and full test suite to validate.